### PR TITLE
Add proper Elixir EEx extension

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -42,6 +42,7 @@ exports.HTML_LANGUAGES = [
     'haml',
     'handlebars',
     'html',
+    'HTML (EEx)',
     'HTML (Eex)',
     'jade',
     'leaf',


### PR DESCRIPTION
Related issue: https://github.com/JakeBecker/vscode-elixir-ls/issues/132

This should fix autocompletion for Embedded Elixir templates.