### PR TITLE
Add support for html.twig as HTML language

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -55,6 +55,7 @@ export const HTML_LANGUAGES: string[] = [
   'slim',
   'svelte',
   'twig',
+  'html.twig',
   'vue',
   ...JS_LANGUAGES
 ]


### PR DESCRIPTION
Vim uses `html.twig` for Twig files by default. I'm not sure if this should replace `twig` or not, so I left the previous line in.

This would fix #9 