### PR TITLE
add elixir filetypes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -37,7 +37,9 @@ export const JS_LANGUAGES: string[] = [
 export const HTML_LANGUAGES: string[] = [
   'blade',
   'edge',
+  'eelixir',
   'ejs',
+  'elixir',
   'erb',
   'eruby',
   'haml',


### PR DESCRIPTION
my vim sees eex files as eelixir, also html can be included in elixir files as sigils