### PR TITLE
Adding support for tailwind ppx

### DIFF
--- a/lsp/tailwindcss-language-server/dist/index.js
+++ b/lsp/tailwindcss-language-server/dist/index.js
@@ -6148,14 +6148,14 @@ module.exports = (function(e, t) {
           end: t
         };
         const n = e.getText(r);
-        if (!/\bclass(Name)?[= ]['"][^'"]*$/.test(n)) return null;
+        if (!/\bclass(Name)?[= ](?:\[%tw )?["']([^"']*)$/.test(n)) return null;
         const i = {
           start: { line: Math.max(t.line - 5, 0), character: 0 },
           end: { line: t.line + 1, character: t.character }
         };
         const o = e.getText(i);
         let a = n + o.substr(n.length).match(/^([^"' ]*)/)[0];
-        let s = a.match(/\bclass(Name)?[= ]["']([^"']*)$/);
+        let s = a.match(/\bclass(Name)?[= ](?:\[%tw )?["']([^"']*)$/);
         if (s && s[2]) {
           let e = s[2].split(" ").pop();
           if (!e) return null;
@@ -6390,7 +6390,7 @@ module.exports = (function(e, t) {
       function getClassListsInHtmlRange(e, t) {
         let r = e.getText(t);
         let n = t ? e.offsetAt(t.start) : 0;
-        let i = find(/\bclass(Name)?[= ](['"{])/g, r);
+        let i = find(/\bclss(Name)?[= ](?:\[%tw )?(['"{])/g, r);
         return flatten(
           i.map(t => {
             if (t[2] === "{") {
@@ -6880,7 +6880,7 @@ module.exports = (function(e, t) {
           let e = /@apply\s+[^;]*$/.test(o);
           if (e || !n) return e;
         }
-        let a = find(/\bclass(Name)?[= ](['"{])/g, o);
+        let a = find(/\bclass(Name)?[= ](?:\[%tw )?(['"{])/g, o);
         if (a.length > 0) {
           let e = a[a.length - 1];
           let t = e.index + 7 + (e[1] ? e[1].length : 0);
@@ -6905,7 +6905,9 @@ module.exports = (function(e, t) {
               );
             }
           } else {
-            return o.substr(t).indexOf(e[2]) === -1;
+            // TODO is this correct?
+            // return o.substr(t).indexOf(e[2]) === -1;
+            return true;
           }
         }
         return false;

--- a/lsp/tailwindcss-language-server/dist/index.js
+++ b/lsp/tailwindcss-language-server/dist/index.js
@@ -6148,7 +6148,7 @@ module.exports = (function(e, t) {
           end: t
         };
         const n = e.getText(r);
-        if (!/\bclass(Name)?[= ](?:\[%tw )?["']([^"']*)$/.test(n)) return null;
+        if (!/\bclass(Name)?[= ](?:\[%tw )?["'][^"']*$/.test(n)) return null;
         const i = {
           start: { line: Math.max(t.line - 5, 0), character: 0 },
           end: { line: t.line + 1, character: t.character }
@@ -6390,7 +6390,7 @@ module.exports = (function(e, t) {
       function getClassListsInHtmlRange(e, t) {
         let r = e.getText(t);
         let n = t ? e.offsetAt(t.start) : 0;
-        let i = find(/\bclss(Name)?[= ](?:\[%tw )?(['"{])/g, r);
+        let i = find(/\bclass(Name)?[= ](?:\[%tw )?(['"{])/g, r);
         return flatten(
           i.map(t => {
             if (t[2] === "{") {
@@ -6904,10 +6904,10 @@ module.exports = (function(e, t) {
                 o.substr(t).replace(/(['"])[^'"]*\1/g, "")
               );
             }
+          } else if (/%tw ['"]/.test(o.substr(t))) {
+            return o.substr(t + 5).indexOf(e[2]) === -1;
           } else {
-            // TODO is this correct?
-            // return o.substr(t).indexOf(e[2]) === -1;
-            return true;
+            return o.substr(t).indexOf(e[2]) === -1;
           }
         }
         return false;
@@ -49587,4 +49587,3 @@ module.exports = (function(e, t) {
     })();
   }
 );
-


### PR DESCRIPTION
This is an exploratory pull request to add support for tailwind-ppx, a Reason/OCaml ppx that helps you validate your Tailwind classes at compile-time: https://github.com/dylanirlbeck/tailwind-ppx. The syntax is as follows:

```reason
<Component className=[%tw "flex flex-row"] />
```

I do need help understanding what to do with line `6908`, since the only way you get auto completion to show up is by forcing the function to return `true`. 

Feel free to reject this pull request, though I thought that modifying the regexp adds little to no overhead to the language server. Cheers!