### PR TITLE
Add "htmldjango" to defaults for html languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ tailwind init
 - `tailwindCSS.htmlLanguages` html languages completion support, default:
 
   ``` jsonc
-  [ "blade", "edge", "eelixir", "ejs", "elixir", "elm", "erb", "eruby", "haml", "handlebars", "html", "HTML (EEx)", "HTML (Eex)", "html.twig", "jade", "leaf", "markdown", "njk", "nunjucks", "php", "razor", "slim", "svelte", "twig", "vue" ]
+  [ "blade", "edge", "eelixir", "ejs", "elixir", "elm", "erb", "eruby", "haml", "handlebars", "htmldjango", "html", "HTML (EEx)", "HTML (Eex)", "html.twig", "jade", "leaf", "markdown", "njk", "nunjucks", "php", "razor", "slim", "svelte", "twig", "vue" ]
   ```
 
 

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
             "haml",
             "handlebars",
             "html",
+            "htmldjango",
             "HTML (EEx)",
             "HTML (Eex)",
             "html.twig",


### PR DESCRIPTION
This pull request adds `htmldjango` to the defaults, since it's the `vim` syntax for HTML files using the Django framework.