### PR TITLE
Add better headwind regex for reason/javascript/javascriptreact/typescript/typescriptreact

### DIFF
--- a/package.json
+++ b/package.json
@@ -1319,14 +1319,14 @@
         "tailwindCSS.headwind.classRegex": {
           "type": "object",
           "default": {
-            "reason": "(?:\\bclassName\\s*=\\s*[\\\"\\']([_a-zA-Z0-9\\s\\-\\:\\/]+)[\\\"\\'])|(?:\\btw\\s*`([_a-zA-Z0-9\\s\\-\\:\\/]*)`)",
+            "reason": "(?:\\bclassName\\s*=[\\w\\d\\s_,{}\\(\\)\\[\\]]*[\"']([\\w\\d\\s_\\-\\:\\/]*)[\"'][\\w\\d\\s_,{}\\(\\)\\[\\]]*)|(?:\\btw\\s*`([\\w\\d\\s_\\-\\:\\/]*)`)",
             "elm": "\\bclass\\s*\\\"([_a-zA-Z0-9\\s\\-\\:\\/]+)\\\"",
             "html": "\\bclass\\s*=\\s*[\\\"\\']([_a-zA-Z0-9\\s\\-\\:\\/]+)[\\\"\\']",
             "css": "\\B@apply\\s+([_a-zA-Z0-9\\s\\-\\:\\/]+);",
-            "javascript": "(?:\\bclassName\\s*=\\s*[\\\"\\']([_a-zA-Z0-9\\s\\-\\:\\/]+)[\\\"\\'])|(?:\\btw\\s*`([_a-zA-Z0-9\\s\\-\\:\\/]*)`)",
-            "javascriptreact": "(?:\\bclassName\\s*=\\s*[\\\"\\']([_a-zA-Z0-9\\s\\-\\:\\/]+)[\\\"\\'])|(?:\\btw\\s*`([_a-zA-Z0-9\\s\\-\\:\\/]*)`)",
-            "typescript": "(?:\\bclassName\\s*=\\s*[\\\"\\']([_a-zA-Z0-9\\s\\-\\:\\/]+)[\\\"\\'])|(?:\\btw\\s*`([_a-zA-Z0-9\\s\\-\\:\\/]*)`)",
-            "typescriptreact": "(?:\\bclassName\\s*=\\s*[\\\"\\']([_a-zA-Z0-9\\s\\-\\:\\/]+)[\\\"\\'])|(?:\\btw\\s*`([_a-zA-Z0-9\\s\\-\\:\\/]*)`)"
+            "javascript": "(?:\\bclassName\\s*=[\\w\\d\\s_,{}\\(\\)\\[\\]]*[\"']([\\w\\d\\s_\\-\\:\\/]*)[\"'][\\w\\d\\s_,{}\\(\\)\\[\\]]*)|(?:\\btw\\s*`([\\w\\d\\s_\\-\\:\\/]*)`)",
+            "javascriptreact": "(?:\\bclassName\\s*=[\\w\\d\\s_,{}\\(\\)\\[\\]]*[\"']([\\w\\d\\s_\\-\\:\\/]*)[\"'][\\w\\d\\s_,{}\\(\\)\\[\\]]*)|(?:\\btw\\s*`([\\w\\d\\s_\\-\\:\\/]*)`)",
+            "typescript": "(?:\\bclassName\\s*=[\\w\\d\\s_,{}\\(\\)\\[\\]]*[\"']([\\w\\d\\s_\\-\\:\\/]*)[\"'][\\w\\d\\s_,{}\\(\\)\\[\\]]*)|(?:\\btw\\s*`([\\w\\d\\s_\\-\\:\\/]*)`)",
+            "typescriptreact": "(?:\\bclassName\\s*=[\\w\\d\\s_,{}\\(\\)\\[\\]]*[\"']([\\w\\d\\s_\\-\\:\\/]*)[\"'][\\w\\d\\s_,{}\\(\\)\\[\\]]*)|(?:\\btw\\s*`([\\w\\d\\s_\\-\\:\\/]*)`)"
           },
           "description": "An object with language IDs as keys and their values determining the regex to search for Tailwind CSS classes.",
           "scope": "window"


### PR DESCRIPTION
This should be a better regex that works with curly braces `{}` in react jsx (I believe it should work in reason as well?) 

Now works with the following:
`className="class1 class2"`
`className='class1 class2'`
`className={"class1 class2"}`
`className={'class1 class2'}`
`className={clsx("class1 class2")}`
`className={clsx(foo, bar, "class1 class2", bar)}`
`className={classname(foo, bar, "class1 class2", bar)}`
`className={anything(foo, bar, "class1 class2", bar)}`


Issues:
- Only sorts first string it encounters i.e.only sorts the first string ("class1 class2") in 
`className={clsx("class1 class2", foo, bar, "class3 class4", bar)}`